### PR TITLE
Pump to 0.9.4.1

### DIFF
--- a/nix/packages/fcitx5-vmk/default.nix
+++ b/nix/packages/fcitx5-vmk/default.nix
@@ -6,24 +6,24 @@
   extra-cmake-modules,
   pkg-config,
   go,
-  gcc,
   gettext,
   hicolor-icon-theme,
   fcitx5,
   libinput,
   xorg,
+  libcap,
   udev,
 }:
 stdenv.mkDerivation rec {
   pname = "fcitx5-vmk";
-  version = "0.9.4";
+  version = "0.9.4.1";
 
   src = fetchFromGitHub {
-    inherit version;
     owner = "nhktmdzhg";
     repo = "VMK";
     rev = "v${version}";
-    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    fetchSubmodules = true;
+    sha256 = "sha256-fnDvwcJJzfVlobAMubRDCovqJR9BjrzZsvcuHFmRG74=";
   };
 
   nativeBuildInputs = [
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
     extra-cmake-modules
     pkg-config
     go
-    gcc
     gettext
     hicolor-icon-theme
   ];
@@ -40,28 +39,37 @@ stdenv.mkDerivation rec {
     fcitx5
     libinput
     xorg.libX11
+    libcap
     udev
   ];
 
-  dontUseCmakeConfigure = true;
-
-  preBuild = ''
+  preConfigure = ''
     export GOCACHE=$TMPDIR/go-cache
     export GOPATH=$TMPDIR/go
+
+    cd bamboo
+    go mod vendor
+    cd ..
   '';
 
-  buildPhase = ''
-    runHook preBuild
-    cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib .
-    make
-    runHook postBuild
-  '';
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DGO_FLAGS=-mod=vendor"
+  ];
 
-  installFlags = ["DESTDIR=$(out)" "PREFIX="];
+  # change checking exe_path logic to make it work on NixOS since executable files on NixOS are not located in /usr/bin
+  postPatch = ''
+    substituteInPlace server/vmk-server.cpp \
+      --replace 'std::string(exe_path) == "/usr/bin/fcitx5"' \
+                '({ std::string p(exe_path); p.find("/nix/store/") == 0 && p.size() >= 11 && p.compare(p.size() - 11, 11, "/bin/fcitx5") == 0; })'
+  '';
 
   postInstall = ''
-    substituteInPlace $out/lib/systemd/system/fcitx5-vmk-server@.service \
-      --replace "/usr/bin/fcitx5-vmk-server" "$out/bin/fcitx5-vmk-server"
+    if [ -d "$out/lib/systemd/system" ]; then
+      substituteInPlace $out/lib/systemd/system/fcitx5-vmk-server@.service \
+        --replace "/usr/bin/fcitx5-vmk-server" "$out/bin/fcitx5-vmk-server"
+    fi
   '';
 
   meta = with lib; {


### PR DESCRIPTION
PR này cập nhật phiên bản lên 0.9.4.1 dành cho NixOS. Ngoài ra, nó sẽ thay đổi logic check exe_path trong file `server/vmk-server.cpp` trước khi build. Trên NixOS, các file thực thi không nằm ở `/usr/bin` mà ở `/nix/store/<a_long_hash>/bin`.